### PR TITLE
Add 'time_format' to return formatted time value

### DIFF
--- a/test/plugin/test_out_dbi.rb
+++ b/test/plugin/test_out_dbi.rb
@@ -13,6 +13,15 @@ class DbiOutputTest < Test::Unit::TestCase
     query insert into logs (aaa, bbb, ccc) values (?, ?, ?)
   ]
 
+  CONFIG_TIME_FORMAT = %[
+    dsn = DBI:drv:dbname:hostname
+    db_user username
+    db_pass password
+    keys aaa,bbb,ccc
+    query insert into logs (aaa, bbb, ccc) values (?, ?, ?)
+    time_format %Y-%m-%d %H-%M-%S
+  ]
+
   def create_driver(conf=CONFIG)
     Fluent::Test::OutputTestDriver.new(Fluent::DbiOutput) do
     end.configure(conf)
@@ -25,5 +34,17 @@ class DbiOutputTest < Test::Unit::TestCase
     assert_equal "password", d.instance.db_pass
     assert_equal "insert into logs (aaa, bbb, ccc) values (?, ?, ?)", d.instance.query
     assert_equal keys, d.instance.keys
+    assert_equal nil, d.instance.time_format
   end
+
+  def test_configure_time_format
+    d = create_driver(CONFIG_TIME_FORMAT)
+    keys = ["aaa", "bbb", "ccc"]
+    assert_equal "username", d.instance.db_user
+    assert_equal "password", d.instance.db_pass
+    assert_equal "insert into logs (aaa, bbb, ccc) values (?, ?, ?)", d.instance.query
+    assert_equal keys, d.instance.keys
+    assert_equal '%Y-%m-%d %H-%M-%S', d.instance.time_format
+  end
+
 end


### PR DESCRIPTION
Add the format of the time written in database.

I wrote this pull-request to store `time` such DATETIME or TIMESTAMP format into a database. 

By this fix, dbi-plugin will treat `time` key  as formatted-string or unix time value(if time_format is not specified)

usage:

```
<match dbi.*>
  type dbi
  dsn DBI:Mysql:dbname:dbhost
  db_user username
  db_pass password
  keys host,time,method,uri,protocol,status
  query insert into access_log (host, time, method, uri, protocol, status) values (?, ?, ?, ?, ?, ?)
  time_format %Y-%m-%d %H-%M-%S  
</match>
```

How do you like?
