### PR TITLE
Add a link to fluentd.org in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Fluent::Plugin::Dbi
+# Fluent::Plugin::Dbi, a plugin for [Fluentd](http://fluentd.org)
 
 Fluentd Output plugin using DBI
 


### PR DESCRIPTION
I am adding a link to Fluentd.org in your README.md file to put Fluentd in context for newcomers.
