### PR TITLE
Add a secret parameter

### DIFF
--- a/lib/fluent/plugin/out_dbi.rb
+++ b/lib/fluent/plugin/out_dbi.rb
@@ -6,7 +6,7 @@ class DbiOutput < BufferedOutput
   config_param :dsn, :string
   config_param :keys, :string
   config_param :db_user, :string
-  config_param :db_pass, :string
+  config_param :db_pass, :string, secret: true
   config_param :query, :string
 
   def initialize


### PR DESCRIPTION
`db_pas`s contains sensitive information.
This parameter should be concealed with secret parameter feature.

This feature works as below:

```log
  <match dbi.*>
    type dbi
    dsn DBI:Mysql:dbname:dbhost
    db_user username
    db_pass xxxxxx
    keys host,time_m,method,uri,protocol,status
    query insert into access_log (host, time, method, uri, protocol, status) values (?, ?, ?, ?, ?, ?)
  </match>
</ROOT>
```

And this secret parameter will be ignored when users use Fluentd 0.10 or older. 