### PR TITLE
Use test-unit gem explicitly

### DIFF
--- a/fluent-plugin-dbi.gemspec
+++ b/fluent-plugin-dbi.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rake"
   gem.add_development_dependency "fluentd"
   gem.add_development_dependency "dbi"
+  gem.add_development_dependency "test-unit", ">= 3.1.0"
   gem.add_runtime_dependency "fluentd"
   gem.add_runtime_dependency "dbi"
 end


### PR DESCRIPTION
Because Ruby 2.2 does not provide minitest with test-unit compatibile layer.